### PR TITLE
add conda-forge info

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ RMSD: 2.6444 Angstrom
 
 ## Quick Install
 
-- latest version (from GitHub): `pip install git+git://github.com/rasbt/biopandas.git#egg=biopandas`
-- latest PyPI version: `pip install biopandas`
+- install the latest version (from GitHub): `pip install git+git://github.com/rasbt/biopandas.git#egg=biopandas`
+- install the latest PyPI version: `pip install biopandas`
+- install biopandas via conda-forge: `conda install biopandas -c conda-forge`
+
 
 For more information, please see [http://rasbt.github.io/biopandas/installation/](http://rasbt.github.io/biopandas/installation/).

--- a/docs/sources/installation.md
+++ b/docs/sources/installation.md
@@ -2,11 +2,33 @@
 
 
 
-You can install `biopandas` directly via pip by executing the following code from your command line:  
+## PyPI
+
+You can install the latest stable release of `biopandas` directly from Python's package index via `pip` by executing the following code from your command line:  
 
 ```bash
 pip install biopandas  
 ```
+
+## Conda-forge
+
+The latest stable release of `biopandas` is now also available via [conda-forge](https://github.com/conda-forge/biopandas-feedstock); you can install it via
+
+
+```bash
+conda install biopandas -c conda-forge
+```
+
+ or simply
+
+ ```bash
+conda install biopandas
+```
+if you have `conda-forge` already [added to your channels](https://github.com/conda-forge/biopandas-feedstock).
+
+
+
+## Latest GitHub Source Code
 
 <br>
 


### PR DESCRIPTION
### Description

Adds installation info about conda-forge to the installation sections in the docs.

