### PR TITLE
let distance methods accept external data frames

### DIFF
--- a/biopandas/__init__.py
+++ b/biopandas/__init__.py
@@ -4,5 +4,5 @@
 # Project Website: http://rasbt.github.io/biopandas/
 # Code Repository: https://github.com/rasbt/biopandas
 
-__version__ = '0.2.2'
+__version__ = '0.2.3dev0'
 __author__ = "Sebastian Raschka <mail@sebastianraschka.com>"

--- a/biopandas/mol2/pandas_mol2.py
+++ b/biopandas/mol2/pandas_mol2.py
@@ -227,11 +227,14 @@ class PandasMol2(object):
         rmsd = round((total.sum() / df1.shape[0])**0.5, 4)
         return rmsd
 
-    def distance(self, xyz=(0.00, 0.00, 0.00)):
+    def distance(self, df=None, xyz=(0.00, 0.00, 0.00)):
         """Computes Euclidean distance between atoms and a 3D point.
 
         Parameters
         ----------
+        df : DataFrame, default: None
+            If a DataFrame is provided as an argument, uses this DataFrame
+            for the distance computation instead of `self.df`.
         xyz : tuple (0.00, 0.00, 0.00)
             X, Y, and Z coordinate of the reference center for the distance
             computation
@@ -242,18 +245,10 @@ class PandasMol2(object):
             distance between the atoms in the atom section and `xyz`.
 
         """
-        return pd.Series(np.linalg.norm(self.df[['x', 'y', 'z']]
-                                        .subtract(xyz, axis=1), axis=1))
+        if df is None:
+            use_df = self.df
+        else:
+            use_df = df
 
-        # Note:
-        # The solution above is about 10% faster than
-        #
-        # return np.sqrt(np.sum(self.df[['x', 'y', 'z']]\
-        #   .subtract(xyz, axis=1)**2, axis=1))
-        #
-        # The solution below is equivalent but 300% slower:
-        #
-        # return self.df.apply(lambda x: np.sqrt(np.sum(
-        #    ((x['x'] - xyz[0])**2,
-        #     (x['y'] - xyz[1])**2,
-        #     (x['z'] - xyz[2])**2))), axis=1)
+        return np.sqrt(np.sum(use_df[['x', 'y', 'z']]
+                       .subtract(xyz, axis=1)**2, axis=1))

--- a/biopandas/mol2/tests/test_pandas_mol2.py
+++ b/biopandas/mol2/tests/test_pandas_mol2.py
@@ -59,6 +59,14 @@ def test_distance():
     assert round(pdmol.distance().values[0], 3) == 31.185
 
 
+def test_distance_external_df():
+    data_path = os.path.join(this_dir, 'data', '1b5e_1.mol2')
+
+    pdmol = PandasMol2().read_mol2(data_path)
+    new_df = pdmol.df.iloc[1:, :].copy()
+    assert round(pdmol.distance(df=new_df).values[0], 3) == 31.165
+
+
 def test_overwrite_df():
     data_path = os.path.join(this_dir, 'data', '1b5e_1.mol2')
     pdmol = PandasMol2().read_mol2(data_path)

--- a/biopandas/pdb/pandas_pdb.py
+++ b/biopandas/pdb/pandas_pdb.py
@@ -31,18 +31,18 @@ class PandasPdb(object):
         Dictionary storing pandas DataFrames for PDB record sections.
         The dictionary keys are {'ATOM', 'HETATM', 'ANISOU', 'OTHERS'}
         where 'OTHERS' contains all entries that are not parsed as
-        'ATOM', 'HETATM', or 'ANISOU'
+        'ATOM', 'HETATM', or 'ANISOU'.
 
     pdb_text : str
-        PDB file contents in raw text format
+        PDB file contents in raw text format.
 
     pdb_path : str
         Location of the PDB file that was read in via `read_pdb`
         or URL of the page where the PDB content was fetched from
-        if `fetch_pdb` was called
+        if `fetch_pdb` was called.
 
     header : str
-        PDB file description
+        PDB file description.
 
     code : str
         PDB code
@@ -75,7 +75,7 @@ class PandasPdb(object):
         Attributes
         ----------
         path : str
-            Path to the PDB file in .pdb format or gzipped format (.pdb.gz)
+            Path to the PDB file in .pdb format or gzipped format (.pdb.gz).
 
         Returns
         ---------
@@ -93,7 +93,7 @@ class PandasPdb(object):
         Parameters
         ----------
         pdb_code : str
-            A 4-letter PDB code, e.g., "3eiy"
+            A 4-letter PDB code, e.g., "3eiy".
 
         Returns
         ---------
@@ -110,15 +110,15 @@ class PandasPdb(object):
         Parameters
         ----------
         s : str  in {'main chain', 'hydrogen', 'c-alpha', 'heavy'}
-            String to specify which entries to return
+            String to specify which entries to return.
 
         df : pandas.DataFrame, default: None
             Optional DataFrame to perform the filter operation on.
-            If df=None, filters on self.df['ATOM']
+            If df=None, filters on self.df['ATOM'].
 
         invert : bool, default: True
             Inverts the search query. For example if s='hydrogen' and
-            invert=True, all but hydrogen entries are returned
+            invert=True, all but hydrogen entries are returned.
 
         Returns
         --------
@@ -139,11 +139,11 @@ class PandasPdb(object):
 
         Parameters
         ----------
-        sections : iterable (default: ('ATOM', 'HETATM'))
+        sections : iterable, default: ('ATOM', 'HETATM')
             Coordinate sections for which the element symbols should be
             imputed.
 
-        inplace : bool (default: False)
+        inplace : bool, (default: False
             Performs the operation in-place if True and returns a copy of the
             PDB DataFrame otherwise.
 
@@ -174,11 +174,11 @@ class PandasPdb(object):
         Parameters
         ----------
         df1 : pandas.DataFrame
-            DataFrame with HETATM, ATOM, and/or ANISOU entries
+            DataFrame with HETATM, ATOM, and/or ANISOU entries.
 
         df2 : pandas.DataFrame
             Second DataFrame for RMSD computation against df1. Must have the
-            same number of entries as df1
+            same number of entries as df1.
 
         s : {'main chain', 'hydrogen', 'c-alpha', 'heavy', 'carbon'} or None,
             default: None
@@ -367,13 +367,13 @@ class PandasPdb(object):
 
         Parameters
         ----------
-        record : str (default: 'ATOM')
-            Specfies the record DataFrame
-        residue_col : str (default: 'residue_name')
+        record : str, default: 'ATOM'
+            Specfies the record DataFrame.
+        residue_col : str,  default: 'residue_name'
             Column in `record` DataFrame to look for 3-letter amino acid
-            codes for the conversion
-        fillna : str (default: '?')
-            Placeholder string to use for unknown amino acids
+            codes for the conversion.
+        fillna : str, default: '?'
+            Placeholder string to use for unknown amino acids.
 
         Returns
         ---------
@@ -397,16 +397,19 @@ class PandasPdb(object):
 
         return pd.concat((tmp.iloc[indices]['chain_id'], transl), axis=1)
 
-    def distance(self, xyz=(0.00, 0.00, 0.00), record='ATOM'):
+    def distance(self, df=None, xyz=(0.00, 0.00, 0.00), record='ATOM'):
         """Computes Euclidean distance between atoms and a 3D point.
 
         Parameters
         ----------
-        xyz : tuple (0.00, 0.00, 0.00)
+        df : DataFrame, default: None
+            If a DataFrame is provided as an argument, uses this DataFrame
+            for the distance computation instead of `self.df[record]`.
+        xyz : tuple, default: (0.00, 0.00, 0.00)
             X, Y, and Z coordinate of the reference center for the distance
-            computation
-        record : str (default: 'ATOM')
-            Specfies the record DataFrame
+            computation.
+        record : str, default: 'ATOM'
+            Specfies the record DataFrame. Only used if `df=None`.
 
         Returns
         ---------
@@ -414,20 +417,14 @@ class PandasPdb(object):
             distance between the atoms in the record section and `xyz`.
 
         """
+        if df is None:
+            use_df = self.df[record]
+        else:
+            use_df = df
 
-        return pd.Series(np.linalg.norm(self.df[record][[
-            'x_coord', 'y_coord', 'z_coord']].subtract(xyz, axis=1), axis=1))
-
-        # Note:
-        # The solution above is about 10% faster than
-        # return np.sqrt(np.sum(self.df[record][[
-        #    'x_coord', 'y_coord', 'z_coord']]\
-        #   .subtract(xyz, axis=1)**2, axis=1))
-        # The solution below is equivalent but 300% slower:
-        # return self.df[record].apply(lambda x: np.sqrt(np.sum(
-        #    ((x['x_coord'] - xyz[0])**2,
-        #     (x['y_coord'] - xyz[1])**2,
-        #     (x['z_coord'] - xyz[2])**2))), axis=1)
+        return np.sqrt(np.sum(use_df[[
+            'x_coord', 'y_coord', 'z_coord']]
+            .subtract(xyz, axis=1)**2, axis=1))
 
     def to_pdb(self, path, records=None, gz=False, append_newline=True):
         """Write record DataFrames to a PDB file or gzipped PDB file.
@@ -440,10 +437,10 @@ class PandasPdb(object):
         records : iterable, default: None
             A list of PDB record sections in
             {'ATOM', 'HETATM', 'ANISOU', 'OTHERS'} that are to be written.
-            Writes all lines to PDB if records=None
+            Writes all lines to PDB if `records=None`.
 
         gz : bool, default: False
-            Writes a gzipped PDB file if True
+            Writes a gzipped PDB file if True.
 
         append_newline : bool, default: True
             Appends a new line at the end of the PDB file if True

--- a/biopandas/pdb/tests/test_distance.py
+++ b/biopandas/pdb/tests/test_distance.py
@@ -21,3 +21,17 @@ def test_equal():
     expect = pd.Series([2.533259, 1.520502, 0.000000, 1.257597, 1.252510],
                        index=[12, 13, 14, 15, 16])
     assert dist[dist < 3].all() == expect.all()
+
+
+def test_use_external_df():
+    TESTDATA_1t48 = os.path.join(os.path.dirname(__file__), 'data',
+                                                            '1t48_995.pdb')
+
+    p1t48 = PandasPdb()
+    p1t48.read_pdb(TESTDATA_1t48)
+    new_df = p1t48.df['ATOM'].iloc[:-1, :].copy()
+    dist = p1t48.distance(df=new_df, xyz=(70.785, 15.477, 23.359))
+
+    expect = pd.Series([2.533259, 1.520502, 0.000000, 1.257597],
+                       index=[12, 13, 14, 15])
+    assert dist[dist < 3].all() == expect.all()

--- a/biopandas/pdb/tests/test_read_pdb.py
+++ b/biopandas/pdb/tests/test_read_pdb.py
@@ -63,7 +63,9 @@ def test_fetch_pdb():
         ppdb = PandasPdb()
         url, txt = ppdb._fetch_pdb('3eiy')
     except HTTPError:
-        pass
+        url, txt = None, None
+    except ConnectionResetError:
+        url, txt = None, None
 
     if txt:  # skip if PDB down
         txt[:100] == three_eiy[:100]

--- a/biopandas/pdb/tests/test_rmsd.py
+++ b/biopandas/pdb/tests/test_rmsd.py
@@ -59,7 +59,7 @@ def test_protein():
 
 
 def test_rna_and_nonmatching_indices():
-    ehz = PandasPdb().fetch_pdb('1ehz')
+    ehz = PandasPdb().read_pdb(TESTDATA_rna)
     at = ehz.df['ATOM']
     a64 = at[at['residue_number'] == 64]
     a66 = at[at['residue_number'] == 66]

--- a/docs/sources/CHANGELOG.md
+++ b/docs/sources/CHANGELOG.md
@@ -3,6 +3,27 @@
 The CHANGELOG for the current development version is available at
 [https://github.com/rasbt/biopandas/blob/master/docs/sources/CHANGELOG.md](https://github.com/rasbt/biopandas/blob/master/docs/sources/CHANGELOG.md).
 
+### 0.2.3dev (TBD)
+
+##### Downloads
+
+- [Source code (zip)]
+- [Source code (tar.gz)]
+
+##### New Features
+
+- -
+
+##### Changes
+
+- `PandasPdb.distance` and `PandasMol2.distancd` now accept external `DataFrames` to allow for more efficient distance computations on smaller `DataFrames` if desired. 
+
+##### Bug Fixes
+
+-
+
+
+
 ### 0.2.2 (06-07-2017)
 
 ##### Downloads


### PR DESCRIPTION
`PandasPdb.distance` and `PandasMol2.distancd` now accept external `DataFrames` to allow for more efficient distance computations on smaller `DataFrames` if desired. Fixes #41