### PR TITLE
Don't import biopandas during install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,13 @@
 from os.path import realpath, dirname, join
 from setuptools import setup, find_packages
-import biopandas
 
-VERSION = biopandas.__version__
+VERSION = None
+with io.open(os.path.join(os.path.dirname(__file__), 'biopandas/__init__.py'), encoding='utf-8') as f:
+    for l in f:
+        if not l.startswith('__version__'):
+            continue
+        VERSION = l.split('=')[1].strip(' "\'\n')
+        break
 PROJECT_ROOT = dirname(realpath(__file__))
 
 REQUIREMENTS_FILE = join(PROJECT_ROOT, 'requirements.txt')

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from os.path import realpath, dirname, join
+import os
 from setuptools import setup, find_packages
 
 VERSION = None
@@ -11,9 +11,9 @@ with open(
             continue
         VERSION = l.split('=')[1].strip(' "\'\n')
         break
-PROJECT_ROOT = dirname(realpath(__file__))
+PROJECT_ROOT = os.path.dirname(os.path.realpath(__file__))
 
-REQUIREMENTS_FILE = join(PROJECT_ROOT, 'requirements.txt')
+REQUIREMENTS_FILE = os.path.join(PROJECT_ROOT, 'requirements.txt')
 
 with open(REQUIREMENTS_FILE) as f:
     install_reqs = f.read().splitlines()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@ from os.path import realpath, dirname, join
 from setuptools import setup, find_packages
 
 VERSION = None
-with io.open(os.path.join(os.path.dirname(__file__), 'biopandas/__init__.py'), encoding='utf-8') as f:
+with io.open(
+    os.path.join(os.path.dirname(__file__), 'biopandas/__init__.py'),
+    encoding='utf-8'
+) as f:
     for l in f:
         if not l.startswith('__version__'):
             continue

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
+import io
 import os
 from setuptools import setup, find_packages
 
 VERSION = None
-with open(
+with io.open(
     os.path.join(os.path.dirname(__file__), 'biopandas/__init__.py'),
     encoding='utf-8'
 ) as f:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from os.path import realpath, dirname, join
 from setuptools import setup, find_packages
 
 VERSION = None
-with io.open(
+with open(
     os.path.join(os.path.dirname(__file__), 'biopandas/__init__.py'),
     encoding='utf-8'
 ) as f:


### PR DESCRIPTION
Getting the __version__ during install is more safely done by reading __init__ as text.

The reason is that __init__ may at some point include code that requires importing packages that have not yet been installed. Installing a package should always be possible using `pip install biopython` in an empty virtualenv.

<!-- Please read the following guidelines for new Pull Requests -- thank you! -->

<!--
Make sure that you submit this pull request as a separate topic branch (and not to "master")
-->

<!-- Provide a small summary describing the Pull Request below -->

### Description

Insert Description Here

### Related issues or pull requests

<!-- Please provide a link to the respective issue on the [Issue Tracker](https://github.com/rasbt/biopandas/issues) if one exists. E.g.,

Fixes #<ISSUE_NUMBER> -->

Link related issues/pull requests here

<!-- Below is a general todo list for typical pull request -->

### Pull Request requirements

For new features or bug fixes, pleas consider the following to-do list:

- [ ] Added appropriate unit test functions in the `./biopandas/*/tests` directories
- [ ] Ran `nosetests ./biopandas -sv` and make sure that all unit tests pass
- [ ] Checked the test coverage by running `nosetests ./biopandas --with-coverage`
- [ ] Checked for style issues by running `flake8 ./biopandas`
- [ ] Added a note about the modification or contribution to the `./docs/sources/`CHANGELOG.md` file
- [ ] Modified documentation in the appropriate location under `biopandas/docs/sources/` (optional)
- [ ] Checked that the Travis-CI build passed at https://travis-ci.org/rasbt/biopandas




<!--
NOTE

Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).

For more information and instructions, please see http://rasbt.github.io/biopandas/contributing/
-->
