### PR TITLE
Raise error if file format is incorrect

### DIFF
--- a/biopandas/__init__.py
+++ b/biopandas/__init__.py
@@ -24,5 +24,5 @@
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
 
-__version__ = '0.2.7'
+__version__ = '0.3.0'
 __author__ = "Sebastian Raschka <mail@sebastianraschka.com>"

--- a/biopandas/mol2/mol2_io.py
+++ b/biopandas/mol2/mol2_io.py
@@ -9,7 +9,8 @@ import gzip
 
 def split_multimol2(mol2_path):
     r"""
-    Splits a multi-mol2 file into individual Mol2 file contents.
+    Generator function that
+    splits a multi-mol2 file into individual Mol2 file contents.
 
     Parameters
     -----------
@@ -26,12 +27,16 @@ def split_multimol2(mol2_path):
         from a gzip (.gz) file.
 
     """
-    if mol2_path.endswith('.gz'):
+    if mol2_path.endswith('.mol2'):
+        open_file = open
+        read_mode = 'r'
+    elif mol2_path.endswith('mol2.gz'):
         open_file = gzip.open
         read_mode = 'rb'
     else:
-        open_file = open
-        read_mode = 'r'
+        raise ValueError('Wrong file format;'
+                         'allowed file formats are .mol2 and .mol2.gz.')
+
     check = {'rb': b'@<TRIPOS>MOLECULE', 'r': '@<TRIPOS>MOLECULE'}
 
     with open_file(mol2_path, read_mode) as f:

--- a/biopandas/mol2/pandas_mol2.py
+++ b/biopandas/mol2/pandas_mol2.py
@@ -169,8 +169,10 @@ class PandasMol2(object):
 
     @staticmethod
     def _get_atomsection(mol2_lst):
-        """Returns atom section from mol2 provided as list of strings"""
+        """Returns atom section from mol2 provided as list of strings.
+        Raises ValueError if data is not provided in the mol2 format."""
         started = False
+        first_idx = None
         for idx, s in enumerate(mol2_lst):
             if s.startswith('@<TRIPOS>ATOM'):
                 first_idx = idx + 1
@@ -178,6 +180,13 @@ class PandasMol2(object):
             elif started and s.startswith('@<TRIPOS>'):
                 last_idx_plus1 = idx
                 break
+        if first_idx is None:
+            # Raise error when file contains no @<TRIPOS>ATOM
+            # (i.e. file is no mol2 file)
+            raise ValueError(
+                    "Structural data could not be loaded. "
+                    "Is the input file/text in the mol2 format?"
+                )
         return mol2_lst[first_idx:last_idx_plus1]
 
     @staticmethod

--- a/biopandas/mol2/tests/test_mol2_io.py
+++ b/biopandas/mol2/tests/test_mol2_io.py
@@ -6,6 +6,7 @@
 
 import os
 from biopandas.mol2.mol2_io import split_multimol2
+from biopandas.testutils import assert_raises
 
 this_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -17,6 +18,19 @@ def test_split_multimol2():
         all_mol2.append(i[0])
     assert(all_mol2[1] == 'ZINC04084113')
     assert(len(all_mol2) == 40)
+
+
+def test_split_multimol2_wrong_format():
+
+    expect = ('Wrong file format;'
+              'allowed file formats are .mol2 and .mol2.gz.')
+
+    def run_code():
+        next(split_multimol2('40_mol2_files.pdb'))
+
+    assert_raises(ValueError,
+                  expect,
+                  run_code)
 
 
 def test_split_multimol2_gz():

--- a/biopandas/mol2/tests/test_pandas_mol2.py
+++ b/biopandas/mol2/tests/test_pandas_mol2.py
@@ -6,6 +6,7 @@
 # Code Repository: https://github.com/rasbt/biopandas
 
 import os
+import pytest
 from biopandas.mol2 import PandasMol2
 from biopandas.mol2.mol2_io import split_multimol2
 from biopandas.testutils import assert_raises
@@ -82,3 +83,10 @@ def test_overwrite_df():
     assert_raises(AttributeError,
                   expect,
                   overwrite)
+
+
+def test__get_atomsection_raises():
+    """Test if ValueError is raised if input list is not in the mol2 format."""
+
+    with pytest.raises(ValueError):
+        PandasMol2()._get_atomsection(["", ""])

--- a/biopandas/mol2/tests/test_pandas_mol2.py
+++ b/biopandas/mol2/tests/test_pandas_mol2.py
@@ -6,7 +6,6 @@
 # Code Repository: https://github.com/rasbt/biopandas
 
 import os
-import pytest
 from biopandas.mol2 import PandasMol2
 from biopandas.mol2.mol2_io import split_multimol2
 from biopandas.testutils import assert_raises
@@ -88,5 +87,12 @@ def test_overwrite_df():
 def test__get_atomsection_raises():
     """Test if ValueError is raised if input list is not in the mol2 format."""
 
-    with pytest.raises(ValueError):
+    expect = ("Structural data could not be loaded. "
+              "Is the input file/text in the mol2 format?")
+
+    def run_code():
         PandasMol2()._get_atomsection(["", ""])
+
+    assert_raises(ValueError,
+                  expect,
+                  run_code)

--- a/biopandas/pdb/pandas_pdb.py
+++ b/biopandas/pdb/pandas_pdb.py
@@ -378,7 +378,7 @@ class PandasPdb(object):
 
             dfs[r[0]] = df
 
-        # issue a warning if no atoms have been loaded 
+        # issue a warning if no atoms have been loaded
         if len(dfs['ATOM']) == 0:
             warnings.warn('No ATOM entries have been loaded. '
                           'Is the input file/text in the pdb format?')

--- a/biopandas/pdb/pandas_pdb.py
+++ b/biopandas/pdb/pandas_pdb.py
@@ -377,6 +377,12 @@ class PandasPdb(object):
                     df[c['id']] = pd.Series(np.nan, index=df.index)
 
             dfs[r[0]] = df
+
+        # issue a warning if no atoms have been loaded 
+        if len(dfs['ATOM']) == 0:
+            warnings.warn('No ATOM entries have been loaded. '
+                          'Is the input file/text in the pdb format?')
+
         return dfs
 
     def amino3to1(self, record='ATOM',

--- a/biopandas/pdb/pandas_pdb.py
+++ b/biopandas/pdb/pandas_pdb.py
@@ -245,12 +245,19 @@ class PandasPdb(object):
     def _read_pdb(path):
         """Read PDB file from local drive."""
         r_mode = 'r'
-        openf = open
-        if path.endswith('.gz'):
+        if path.endswith('.pdb'):
+            openf = open
+        elif path.endswith('pdb.gz'):
             r_mode = 'rb'
             openf = gzip.open
+        else:
+            raise ValueError(
+                'Wrong file format; allowed file formats are .pdb and .pdb.gz.'
+            )
+
         with openf(path, r_mode) as f:
             txt = f.read()
+
         if path.endswith('.gz'):
             if sys.version_info[0] >= 3:
                 txt = txt.decode('utf-8')

--- a/biopandas/pdb/tests/test_read_pdb.py
+++ b/biopandas/pdb/tests/test_read_pdb.py
@@ -10,12 +10,12 @@ import os
 import numpy as np
 import pandas as pd
 from nose.tools import raises
+from biopandas.testutils import assert_raises
 try:
     from urllib.request import urlopen
     from urllib.error import HTTPError, URLError
 except ImportError:
     from urllib2 import urlopen, HTTPError, URLError  # Python 2.7 compatib
-import pytest
 
 
 TESTDATA_FILENAME = os.path.join(os.path.dirname(__file__), 'data', '3eiy.pdb')
@@ -60,10 +60,23 @@ def test__read_pdb():
 def test__read_pdb_raises():
     """Test private _read_pdb:
     Test if ValueError is raised for wrong file formats."""
-    with pytest.raises(ValueError):
+
+    expect = ('Wrong file format; allowed file formats'
+              ' are .pdb and .pdb.gz.')
+
+    def run_code_1():
         PandasPdb()._read_pdb("protein.mol2")
-    with pytest.raises(ValueError):
+
+    assert_raises(ValueError,
+                  expect,
+                  run_code_1)
+
+    def run_code_2():
         PandasPdb()._read_pdb("protein.mol2.gz")
+
+    assert_raises(ValueError,
+                  expect,
+                  run_code_2)
 
 
 def test_fetch_pdb():

--- a/biopandas/pdb/tests/test_read_pdb.py
+++ b/biopandas/pdb/tests/test_read_pdb.py
@@ -15,6 +15,7 @@ try:
     from urllib.error import HTTPError, URLError
 except ImportError:
     from urllib2 import urlopen, HTTPError, URLError  # Python 2.7 compatib
+import pytest
 
 
 TESTDATA_FILENAME = os.path.join(os.path.dirname(__file__), 'data', '3eiy.pdb')
@@ -54,6 +55,15 @@ def test__read_pdb():
     path, txt = ppdb._read_pdb(TESTDATA_FILENAME)
     print(txt)
     assert txt == three_eiy
+
+
+def test__read_pdb_raises():
+    """Test private _read_pdb:
+    Test if ValueError is raised for wrong file formats."""
+    with pytest.raises(ValueError):
+        PandasPdb()._read_pdb("protein.mol2")
+    with pytest.raises(ValueError):
+        PandasPdb()._read_pdb("protein.mol2.gz")
 
 
 def test_fetch_pdb():

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ The CHANGELOG for the current development version is available at
 
 ##### New Features
 
-- -
+- A `PandasPdb.read_pdb_from_list` method was added analogous to the existing `PandasMol2.read_mol2_from_list` (via PR [72](https://github.com/rasbt/biopandas/pull/72/files) by [dominiquesydow](https://github.com/dominiquesydow))
 
 ##### Changes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,27 @@
 The CHANGELOG for the current development version is available at
 [https://github.com/rasbt/biopandas/blob/master/docs/sources/CHANGELOG.md](https://github.com/rasbt/biopandas/blob/master/docs/sources/CHANGELOG.md).
 
+
+### 0.3.0 (TBA)
+
+##### Downloads
+
+- [Source code (zip)](https://github.com/rasbt/biopandas/archive/v0.3.0.zip)
+- [Source code (tar.gz)](https://github.com/rasbt/biopandas/archive/v0.3.0.tar.gz)
+
+##### New Features
+
+- -
+
+##### Changes
+
+- `ValueError` raising and improved file format error messages for `read_pdb` and `read_mol2` functionality. (via PR [73](https://github.com/rasbt/biopandas/pull/73/files) by [dominiquesydow](https://github.com/dominiquesydow))
+
+##### Bug Fixes
+
+- -
+
+
 ### 0.2.7 (08-04-2020)
 
 ##### Downloads


### PR DESCRIPTION
### Code of Conduct

<!-- 
If this is your first Pull Request for the BioPandas repository, please review
the code of conduct, which is available at http://rasbt.github.io/biopandas/CODE_OF_CONDUCT/. 
-->


### Description

<!--  
Please insert a brief description of the Pull request below.
-->

Raise `ValueError` if an incorrect file format is loaded using the `mol2` or `pdb` modules.

Two checks per `mol2`/`pdb` module would be optimal:
1. When loading DataFrames from file: Check if extension is correct (.mol2/.mol2.gz or .pdb/pdb.gz, respectively).
2. When loading DataFrames from text: Check for certain tags in the text?

This PR suggests the following changes:

- [x] pdb from file: Raise `ValueError` in `PandasPdb._read_pdb` if file extension not .pdb/.pdb.gz
- [ ] TBD: pdb from text: Add `len(dfs['ATOM'] == 0` to check if any atomic data was loaded? However, I am not sure if you want 
- [x] mol2 from text: Raise `ValueError` in `PandasPdb._get_atomsection` if format is not mol2 (`@<TRIPOS>ATOM` not found)
this behaviour in general.
- [x] TBD: mol2 from file: Raise error if file extension is incorrect in[ `mol2.mol2_io.split_multimol2`](https://github.com/dominiquesydow/biopandas/blob/8da42c22e848ca62197ab9ccaec09e8b0f5aeb62/biopandas/mol2/mol2_io.py#L10). I tried to add:
```python
    # mol2_io.py
    def split_multimol2(mol2_path):
        if mol2_path.endswith('.mol2'):
            open_file = open
            read_mode = 'r'
        elif mol2_path.endswith('mol2.gz'):
            open_file = gzip.open
            read_mode = 'rb'
        else:
            raise ValueError('Wrong file format; allowed file formats are .mol2 and .mol2.gz.')
        # rest of the function's code
```
However, the error is not thrown, which I don't understand right now.


### Related issues or pull requests

<!--  
If applicable, please link related issues/pull request below. For example,   
"Fixes #366". Note that the "Fixes" keyword in GitHub will automatically
close the listed issue upon merging this Pull Request.
-->

Suggests changes for #71.

### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at http://rasbt.github.io/biopandas/contributing/.
-->

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./biopandas/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `biopandas/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./biopandas -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./biopandas/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./biopandas`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
