### PR TITLE
allow .ent & .ent.gz file extensions

### DIFF
--- a/biopandas/__init__.py
+++ b/biopandas/__init__.py
@@ -24,5 +24,5 @@
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
 
-__version__ = '0.2.8'
+__version__ = '0.2.9dev'
 __author__ = "Sebastian Raschka <mail@sebastianraschka.com>"

--- a/biopandas/pdb/pandas_pdb.py
+++ b/biopandas/pdb/pandas_pdb.py
@@ -263,14 +263,16 @@ class PandasPdb(object):
     def _read_pdb(path):
         """Read PDB file from local drive."""
         r_mode = 'r'
-        if path.endswith('.pdb'):
+        if path.endswith(('.pdb', '.ent')):
             openf = open
-        elif path.endswith('pdb.gz'):
+        elif path.endswith(('pdb.gz', '.ent.gz')):
             r_mode = 'rb'
             openf = gzip.open
         else:
+            allowed_formats = ", ".join(('.pdb', '.pdb.gz', '.ent', '.ent.gz'))
             raise ValueError(
-                'Wrong file format; allowed file formats are .pdb and .pdb.gz.'
+                ('Wrong file format; allowed file formats are %s'
+                  % allowed_formats)
             )
 
         with openf(path, r_mode) as f:

--- a/biopandas/pdb/tests/test_read_pdb.py
+++ b/biopandas/pdb/tests/test_read_pdb.py
@@ -61,8 +61,8 @@ def test__read_pdb_raises():
     """Test private _read_pdb:
     Test if ValueError is raised for wrong file formats."""
 
-    expect = ('Wrong file format; allowed file formats'
-              ' are .pdb and .pdb.gz.')
+    expect = ('Wrong file format; allowed file formats are '
+              '.pdb, .pdb.gz, .ent, .ent.gz')
 
     def run_code_1():
         PandasPdb()._read_pdb("protein.mol2")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,25 @@ The CHANGELOG for the current development version is available at
 [https://github.com/rasbt/biopandas/blob/master/docs/sources/CHANGELOG.md](https://github.com/rasbt/biopandas/blob/master/docs/sources/CHANGELOG.md).
 
 
+### 0.2.9 (TBD)
+
+##### Downloads
+
+- -
+- -
+
+##### New Features
+
+- -
+
+##### Changes
+
+- Now also allow `.ent` and `.ent.gz` file endings for PDB files.  (via PR [82](https://github.com/rasbt/biopandas/pull/82/files)
+
+##### Bug Fixes
+
+- -
+
 ### 0.2.8 (03-30-2021)
 
 ##### Downloads


### PR DESCRIPTION
### Description

Now doesn't throw an error anymore if `.ent` or `.ent.gz` files are encountered.

### Related issues or pull requests

Fixes #81

### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at http://rasbt.github.io/biopandas/contributing/.
-->

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./biopandas/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `biopandas/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./biopandas -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./biopandas/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./biopandas`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
