### PR TITLE
fix bug reg long coordinates

### DIFF
--- a/biopandas/__init__.py
+++ b/biopandas/__init__.py
@@ -24,5 +24,5 @@
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
 
-__version__ = '0.2.9'
+__version__ = '0.3.0dev0'
 __author__ = "Sebastian Raschka <mail@sebastianraschka.com>"

--- a/biopandas/pdb/pandas_pdb.py
+++ b/biopandas/pdb/pandas_pdb.py
@@ -548,6 +548,13 @@ class PandasPdb(object):
                 dfs[r]['OUT'] = pd.Series('', index=dfs[r].index)
 
             for c in dfs[r].columns:
+                # fix issue where coordinates with four or more digits would
+                # cause issues because the columns become too wide
+                if c in {'x_coord', 'y_coord', 'z_coord'}:
+                    for idx in range(dfs[r][c].values.shape[0]):
+                        if len(dfs[r][c].values[idx]) > 8:
+                            dfs[r][c].values[idx] = \
+                                str(dfs[r][c].values[idx]).strip()
                 if c in {'line_idx', 'OUT'}:
                     pass
                 elif r in {'ATOM', 'HETATM'} and c not in pdb_df_columns:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,24 @@
 The CHANGELOG for the current development version is available at
 [https://github.com/rasbt/biopandas/blob/main/docs/sources/CHANGELOG.md](https://github.com/rasbt/biopandas/blob/main/docs/sources/CHANGELOG.md).
 
+### 0.3.0dev0 (TBD)
+
+##### Downloads
+
+- 
+
+##### New Features
+
+- -
+
+##### Changes
+
+- 
+
+##### Bug Fixes
+
+- Fixes a bug where coordinates with more than 4 digits before the decimal point caused a column shift when saving a PDB file. (via PR [90](https://github.com/rasbt/biopandas/pull/90/files)
+
 
 ### 0.2.9 (08-30-2021)
 


### PR DESCRIPTION

### Description

Fixes a bug where coordinates with more than 4 digits before the decimal point caused a column shift when saving a PDB file. 

### Related issues or pull requests

Fixes #89

### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at http://rasbt.github.io/biopandas/contributing/.
-->

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./biopandas/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `biopandas/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./biopandas -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./biopandas/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./biopandas`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
