### PR TITLE
Get carbon bugfix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,9 +2,7 @@ build: false
 
 environment:
   matrix:
-    - PYTHON_VERSION: 2.7
-      MINICONDA: C:\Miniconda
-    - PYTHON_VERSION: 3.5
+    - PYTHON_VERSION: 3.9
       MINICONDA: C:\Miniconda3
 
 init:

--- a/biopandas/pdb/pandas_pdb.py
+++ b/biopandas/pdb/pandas_pdb.py
@@ -358,11 +358,11 @@ class PandasPdb(object):
 
     @staticmethod
     def _get_carbon(df, invert):
-        """Return c-alpha atom entries from a DataFrame"""
+        """Return carbon atom entries from a DataFrame"""
         if invert:
-            return df[df['element_symbol'] == 'C']
-        else:
             return df[df['element_symbol'] != 'C']
+        else:
+            return df[df['element_symbol'] == 'C']
 
     @staticmethod
     def _construct_df(pdb_lines):

--- a/biopandas/pdb/tests/test_read_pdb.py
+++ b/biopandas/pdb/tests/test_read_pdb.py
@@ -192,4 +192,4 @@ def test_get_df():
     assert shape == (1330, 21), shape
 
     shape = ppdb.get('carbon', records=('ATOM',)).shape
-    assert shape == (473, 21), shape
+    assert shape == (857, 21), shape

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,7 +20,7 @@ The CHANGELOG for the current development version is available at
 ##### Bug Fixes
 
 - Fixes a bug where coordinates with more than 4 digits before the decimal point caused a column shift when saving a PDB file. (via PR [90](https://github.com/rasbt/biopandas/pull/90/files)
-
+- Fixes a bug where the invert parameter in get_carbon was selecting the wrong case
 
 ### 0.2.9 (08-30-2021)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,8 +19,8 @@ The CHANGELOG for the current development version is available at
 
 ##### Bug Fixes
 
-- Fixes a bug where coordinates with more than 4 digits before the decimal point caused a column shift when saving a PDB file. (via PR [90](https://github.com/rasbt/biopandas/pull/90/files)
-- Fixes a bug where the invert parameter in get_carbon was selecting the wrong case
+- Fixes a bug where coordinates with more than 4 digits before the decimal point caused a column shift when saving a PDB file. (via PR #[90](https://github.com/rasbt/biopandas/pull/90/files))
+- Fixes a bug where the invert parameter in get_carbon was selecting the wrong case. (via PR #[96](https://github.com/rasbt/biopandas/pull/96/files)) 
 
 ### 0.2.9 (08-30-2021)
 


### PR DESCRIPTION
### Code of Conduct

<!-- 
If this is your first Pull Request for the BioPandas repository, please review
the code of conduct, which is available at http://rasbt.github.io/biopandas/CODE_OF_CONDUCT/. 
-->


### Description
Fixes minor bug where the `invert` parameter in `_get_carbon` was selecting the wrong group.


### Related issues or pull requests
#95

### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at http://rasbt.github.io/biopandas/contributing/.
-->

- [x] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./biopandas/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `biopandas/docs/sources/` (if applicable)
- [x] Ran `PYTHONPATH='.' pytest ./biopandas -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./biopandas/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [ ] Checked for style issues by running `flake8 ./biopandas`

